### PR TITLE
Update NES compatibility json

### DIFF
--- a/_data/compatibility/Nintendo - Nintendo Entertainment System.json
+++ b/_data/compatibility/Nintendo - Nintendo Entertainment System.json
@@ -301,9 +301,9 @@
       "version": "v124"
     },
     "Ai Sensei no Oshiete - Watashi no Hoshi (Japan)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "Aigina no Yogen - Balubalouk no Densetsu Yori (Japan)": {
       "status": "Unknown",
@@ -346,9 +346,9 @@
       "version": "v124"
     },
     "Akira (Japan)": {
-      "status": "Unknown",
-      "notes": "",
-      "version": "v124"
+      "status": "Not Working",
+      "notes": "Hangs after starting game",
+      "version": "v125"
     },
     "Akuma no Shoutaijou (Japan)": {
       "status": "Unknown",
@@ -361,9 +361,9 @@
       "version": "v124"
     },
     "Akumajou Densetsu (Japan)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "Akumajou Dracula (Japan)": {
       "status": "Unknown",
@@ -371,9 +371,9 @@
       "version": "v124"
     },
     "Akumajou Special - Boku Dracula-kun (Japan)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "Al Unser Jr. Turbo Racing (USA)": {
       "status": "Unknown",
@@ -521,9 +521,9 @@
       "version": "v124"
     },
     "Argus (Japan)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "Arkanoid (Japan) (En)": {
       "status": "Unknown",
@@ -641,9 +641,9 @@
       "version": "v124"
     },
     "Babel no Tou (Japan)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "Back to the Future (USA)": {
       "status": "Unknown",
@@ -691,19 +691,19 @@
       "version": "v124"
     },
     "Bakushou!! Jinsei Gekijou (Japan)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "Bakushou!! Jinsei Gekijou 2 (Japan)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "Bakushou!! Jinsei Gekijou 3 (Japan)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "Ballblazer (Japan)": {
       "status": "Unknown",
@@ -1111,14 +1111,14 @@
       "version": "v124"
     },
     "Bio Miracle Bokutte Upa (Japan)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "Bio Senshi Dan - Increaser Tono Tatakai (Japan)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "Bionic Commando (Europe)": {
       "status": "Unknown",
@@ -1296,9 +1296,9 @@
       "version": "v124"
     },
     "Bubble Bobble 2 (Japan)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "Bubble Bobble Part 2 (USA)": {
       "status": "Unknown",
@@ -1441,9 +1441,9 @@
       "version": "v124"
     },
     "Captain Saver (Japan)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "Captain Silver (Japan)": {
       "status": "Unknown",
@@ -1631,9 +1631,9 @@
       "version": "v124"
     },
     "Chibi Maruko-chan - Uki Uki Shopping (Japan)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "Chiisana Obake - Acchi Socchi Kocchi (Japan)": {
       "status": "Unknown",
@@ -1686,14 +1686,14 @@
       "version": "v124"
     },
     "Choplifter (Japan) (En)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "Choplifter (Japan) (En) (Rev 1)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "Chou Fuyuu Yousai Exed Exes (Japan)": {
       "status": "Unknown",
@@ -1771,9 +1771,9 @@
       "version": "v124"
     },
     "City Connection (Japan)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "City Connection (USA)": {
       "status": "Unknown",
@@ -1871,9 +1871,9 @@
       "version": "v124"
     },
     "Contra (Japan)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "Contra (USA)": {
       "status": "Unknown",
@@ -1941,9 +1941,9 @@
       "version": "v124"
     },
     "Crisis Force (Japan)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "CrossFire (Japan)": {
       "status": "Unknown",
@@ -1996,9 +1996,9 @@
       "version": "v124"
     },
     "Daiku no Gen-san 2 - Akage no Dan no Gyakushuu (Japan)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "Daisenryaku (Japan)": {
       "status": "Unknown",
@@ -2236,9 +2236,9 @@
       "version": "v124"
     },
     "Devil Man (Japan)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "Devil World (Europe)": {
       "status": "Unknown",
@@ -2311,9 +2311,9 @@
       "version": "v124"
     },
     "Digital Devil Story - Megami Tensei (Japan)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "Digital Devil Story - Megami Tensei II (Japan)": {
       "status": "Unknown",
@@ -2341,14 +2341,14 @@
       "version": "v124"
     },
     "Don Doko Don (Japan)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "Don Doko Don 2 (Japan)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "Donald Duck (Japan)": {
       "status": "Unknown",
@@ -2611,24 +2611,24 @@
       "version": "v124"
     },
     "Dragon Buster (Japan)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "Dragon Buster (World) (Namcot Collection, Namco Museum Archives Vol 1)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "Dragon Buster II - Yami no Fuuin (Japan)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "Dragon Buster II - Yami no Fuuin (USA, Europe) (Namco Museum Archives Vol 2)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "Dragon Fighter (Japan)": {
       "status": "Unknown",
@@ -2686,19 +2686,19 @@
       "version": "v124"
     },
     "Dragon Scroll - Yomigaerishi Maryuu (Japan)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "Dragon Slayer IV - Drasle Family (Japan)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "Dragon Spirit - Aratanaru Densetsu (Japan)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "Dragon Spirit - The New Legend (USA)": {
       "status": "Unknown",
@@ -2941,9 +2941,9 @@
       "version": "v124"
     },
     "Esper Dream 2 - Aratanaru Tatakai (Japan)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "Excitebike (Europe)": {
       "status": "Unknown",
@@ -2961,9 +2961,9 @@
       "version": "v124"
     },
     "Exciting Boxing (Japan)": {
-      "status": "Unknown",
-      "notes": "",
-      "version": "v124"
+      "status": "Partially Working",
+      "notes": "Required peripheral: Exciting Boxing Punching Bag",
+      "version": "v125"
     },
     "Exciting Rally - World Rally Championship (Japan)": {
       "status": "Unknown",
@@ -3101,19 +3101,19 @@
       "version": "v124"
     },
     "Family Boxing (Japan)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "Family Circuit '91 (Japan) (En)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "Family Circuit (Japan)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "Family Feud (USA)": {
       "status": "Unknown",
@@ -3121,29 +3121,29 @@
       "version": "v124"
     },
     "Family Jockey (Japan)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "Family Mahjong (Japan)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "Family Mahjong (Japan) (Rev A)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "Family Mahjong II - Shanghai e no Michi (Japan)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "Family Pinball (Japan)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "Family Quiz - 4-nin wa Rival (Japan)": {
       "status": "Unknown",
@@ -3156,9 +3156,9 @@
       "version": "v124"
     },
     "Family Tennis (Japan)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "Family Trainer 1 - Athletic World (Japan)": {
       "status": "Unknown",
@@ -3216,9 +3216,9 @@
       "version": "v124"
     },
     "Famista '89 - Kaimaku Ban!! (Japan)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "Famista '90 (Japan)": {
       "status": "Unknown",
@@ -3226,24 +3226,24 @@
       "version": "v124"
     },
     "Famista '91 (Japan)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "Famista '92 (Japan)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "Famista '93 (Japan)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "Famista '94 (Japan)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "Fantasy Zone (Japan) (Sunsoft)": {
       "status": "Unknown",
@@ -3441,9 +3441,9 @@
       "version": "v124"
     },
     "Flintstones, The - The Rescue of Dino & Hoppy (Japan)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "Flintstones, The - The Rescue of Dino & Hoppy (USA)": {
       "status": "Unknown",
@@ -3536,9 +3536,9 @@
       "version": "v124"
     },
     "Fudou Myouou Den (Japan)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "Fun House (USA)": {
       "status": "Unknown",
@@ -3646,34 +3646,34 @@
       "version": "v124"
     },
     "Ganbare Goemon 2 (Japan)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "Ganbare Goemon Gaiden - Kieta Ougon Kiseru (Japan)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "Ganbare Goemon Gaiden - Kieta Ougon Kiseru (Japan) (Rev 1)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "Ganbare Goemon Gaiden 2 - Tenka no Zaihou (Japan)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "Ganbare Goemon! - Karakuri Douchuu (Japan)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "Ganbare Pennant Race! (Japan)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "Ganso Saiyuuki - Super Monkey Daibouken (Japan)": {
       "status": "Unknown",
@@ -3706,9 +3706,9 @@
       "version": "v124"
     },
     "Gauntlet (USA)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "Gauntlet II (Europe)": {
       "status": "Unknown",
@@ -3766,9 +3766,9 @@
       "version": "v124"
     },
     "Genpei Touma Den - Computer Boardgame (Japan)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "George Foreman's KO Boxing (Europe)": {
       "status": "Unknown",
@@ -3781,9 +3781,9 @@
       "version": "v124"
     },
     "Getsu Fuuma Den (Japan)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "Ghost Lion (USA)": {
       "status": "Unknown",
@@ -3866,9 +3866,9 @@
       "version": "v124"
     },
     "Goal!! (Japan)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "God Slayer - Haruka Tenkuu no Sonata (Japan)": {
       "status": "Unknown",
@@ -3941,9 +3941,9 @@
       "version": "v124"
     },
     "Golfkko Open (Japan)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "Golgo 13 - Daiisshou - Kamigami no Tasogare (Japan)": {
       "status": "Unknown",
@@ -3971,9 +3971,9 @@
       "version": "v124"
     },
     "Goonies (Japan)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "Goonies 2 - Fratelli Saigo no Chousen (Japan)": {
       "status": "Unknown",
@@ -4031,9 +4031,9 @@
       "version": "v124"
     },
     "Gradius II (Japan)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "Grand Master (Japan)": {
       "status": "Unknown",
@@ -4246,9 +4246,9 @@
       "version": "v124"
     },
     "Heisei Tensai Bakabon (Japan)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "Hello Kitty no Ohanabatake (Japan)": {
       "status": "Unknown",
@@ -4376,9 +4376,9 @@
       "version": "v124"
     },
     "Holy Diver (Japan)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "Home Alone (USA)": {
       "status": "Unknown",
@@ -4531,9 +4531,9 @@
       "version": "v124"
     },
     "Hyper Olympic (Japan) (Genteiban!)": {
-      "status": "Unknown",
-      "notes": "",
-      "version": "v124"
+      "status": "Partially Working",
+      "notes": "Required peripheral: Konami Hyper Shot",
+      "version": "v125"
     },
     "Hyper Sports (Japan)": {
       "status": "Unknown",
@@ -4686,9 +4686,9 @@
       "version": "v124"
     },
     "Image Fight (Japan)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "Image Fight (USA)": {
       "status": "Unknown",
@@ -4746,9 +4746,9 @@
       "version": "v124"
     },
     "Insector X (Japan)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "International Cricket (Australia)": {
       "status": "Unknown",
@@ -4851,19 +4851,19 @@
       "version": "v124"
     },
     "Jajamaru Gekimaden - Maboroshi no Kinmajou (Japan)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "Jajamaru Ninpou Chou (Japan)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "Jajamaru no Daibouken (Japan)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "James Bond Jr (Europe)": {
       "status": "Unknown",
@@ -4881,9 +4881,9 @@
       "version": "v124"
     },
     "Jarinko Chie - Bakudan Musume no Shiawase Sagashi (Japan)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "Jaws (USA)": {
       "status": "Unknown",
@@ -4926,9 +4926,9 @@
       "version": "v124"
     },
     "Jetsons, The - Cogswell's Caper (Japan)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "Jetsons, The - Cogswell's Caper (USA)": {
       "status": "Unknown",
@@ -4941,9 +4941,9 @@
       "version": "v124"
     },
     "Jikuu Yuuden - Debias (Japan)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "Jimmy Connors Tennis (Europe)": {
       "status": "Unknown",
@@ -5091,9 +5091,9 @@
       "version": "v124"
     },
     "Kage no Densetsu (Japan)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "Kagerou Densetsu (Japan)": {
       "status": "Unknown",
@@ -5111,19 +5111,19 @@
       "version": "v124"
     },
     "Kaiketsu Yancha Maru (Japan)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "Kaiketsu Yancha Maru 2 - Karakuri Land (Japan)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "Kaiketsu Yancha Maru 3 - Taiketsu! Zouringen (Japan)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "Kakefu-kun no Jump Tengoku - Speed Jigoku (Japan)": {
       "status": "Unknown",
@@ -5201,19 +5201,19 @@
       "version": "v124"
     },
     "Karnov (Japan)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "Karnov (Japan) (Rev 1)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "Karnov (USA)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "Kawa no Nushi Tsuri (Japan)": {
       "status": "Unknown",
@@ -5251,9 +5251,9 @@
       "version": "v124"
     },
     "Ki no Bouken - The Quest of Ki (Japan)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "Kick Off (Europe)": {
       "status": "Unknown",
@@ -5321,9 +5321,9 @@
       "version": "v124"
     },
     "King Kong 2 - Ikari no Megaton Punch (Japan)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "King of Kings (Japan)": {
       "status": "Unknown",
@@ -5431,9 +5431,9 @@
       "version": "v124"
     },
     "Konami Wai Wai World (Japan)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "Konamic Sports in Seoul (Japan)": {
       "status": "Unknown",
@@ -5501,9 +5501,9 @@
       "version": "v124"
     },
     "Kyonshiizu 2 (Japan)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "Kyoro-chan Land (Japan)": {
       "status": "Unknown",
@@ -5511,9 +5511,9 @@
       "version": "v124"
     },
     "Kyoto Hana no Misshitsu Satsujin Jiken (Japan)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "Kyoto Ryuu no Tera Satsujin Jiken (Japan)": {
       "status": "Unknown",
@@ -5526,29 +5526,29 @@
       "version": "v124"
     },
     "Kyuukyoku Harikiri Koushien (Japan)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "Kyuukyoku Harikiri Stadium (Japan)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "Kyuukyoku Harikiri Stadium - '88 Senshu Shin Data Version (Japan)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "Kyuukyoku Harikiri Stadium - Heisei Gannen Ban (Japan)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "Kyuukyoku Harikiri Stadium III (Japan)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "Kyuukyoku Tiger (Japan)": {
       "status": "Unknown",
@@ -5561,14 +5561,14 @@
       "version": "v124"
     },
     "Lagrange Point (Japan)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "Lasalle Ishii no Child's Quest (Japan)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "Laser Invasion (USA)": {
       "status": "Unknown",
@@ -5786,9 +5786,9 @@
       "version": "v124"
     },
     "Lord of King, The (Japan)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "Lost Word of Jenny - Ushinawareta Message (Japan)": {
       "status": "Unknown",
@@ -5826,9 +5826,9 @@
       "version": "v124"
     },
     "Lupin Sansei - Pandora no Isan (Japan)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "M.C. Kids (USA)": {
       "status": "Unknown",
@@ -5896,9 +5896,9 @@
       "version": "v124"
     },
     "Magic John (Japan)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "Magic Johnson's Fast Break (USA)": {
       "status": "Unknown",
@@ -6011,9 +6011,9 @@
       "version": "v124"
     },
     "Major League (Japan)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "Major League Baseball (USA)": {
       "status": "Unknown",
@@ -6091,9 +6091,9 @@
       "version": "v124"
     },
     "Mappy-Land (Japan)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "Mappy-Land (USA)": {
       "status": "Unknown",
@@ -6301,9 +6301,9 @@
       "version": "v124"
     },
     "Meikyuu-jima (Japan)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "Meimon! Daisan Yakyuubu (Japan)": {
       "status": "Unknown",
@@ -6376,9 +6376,9 @@
       "version": "v124"
     },
     "Metro-Cross (Japan)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "Metroid (Europe)": {
       "status": "Unknown",
@@ -6396,9 +6396,9 @@
       "version": "v124"
     },
     "Mezase! Top Pro - Green ni Kakeru Yume (Japan)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "Michael Andretti's World GP (USA)": {
       "status": "Unknown",
@@ -6516,9 +6516,9 @@
       "version": "v124"
     },
     "Minelvaton Saga - Ragon no Fukkatsu (Japan)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "Mini-Putt (Japan)": {
       "status": "Unknown",
@@ -6556,9 +6556,9 @@
       "version": "v124"
     },
     "Mirai Shinwa Jarvas (Japan)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "Mission - Impossible (Europe)": {
       "status": "Unknown",
@@ -6576,14 +6576,14 @@
       "version": "v124"
     },
     "Mississippi Satsujin Jiken (Japan)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "Mississippi Satsujin Jiken (Japan) (Rev A)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "Mito Koumon - Sekai Manyuu Ki (Japan)": {
       "status": "Unknown",
@@ -6606,14 +6606,14 @@
       "version": "v124"
     },
     "Moe Pro! '90 - Kandou Hen (Japan)": {
-      "status": "Unknown",
-      "notes": "",
-      "version": "v124"
+      "status": "Working",
+      "notes": "Missing samples: uses ADPCM speech chip with internal ROM (not dumped)",
+      "version": "v125"
     },
     "Moe Pro! - Saikyou Hen (Japan)": {
-      "status": "Unknown",
-      "notes": "",
-      "version": "v124"
+      "status": "Working",
+      "notes": "Missing samples: uses ADPCM speech chip with internal ROM (not dumped)",
+      "version": "v125"
     },
     "Moero TwinBee - Cinnamon Hakase o Sukue! (Japan)": {
       "status": "Unknown",
@@ -6621,49 +6621,49 @@
       "version": "v124"
     },
     "Moero!! Junior Basket - Two on Two (Japan)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "Moero!! Juudou Warriors (Japan)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "Moero!! Pro Soccer (Japan)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "Moero!! Pro Tennis (Japan)": {
-      "status": "Unknown",
-      "notes": "",
-      "version": "v124"
+      "status": "Working",
+      "notes": "Missing samples: uses ADPCM speech chip with internal ROM (not dumped)",
+      "version": "v125"
     },
     "Moero!! Pro Yakyuu '88 - Ketteiban (Japan)": {
-      "status": "Unknown",
-      "notes": "",
-      "version": "v124"
+      "status": "Working",
+      "notes": "Missing samples: uses ADPCM speech chip with internal ROM (not dumped)",
+      "version": "v125"
     },
     "Moero!! Pro Yakyuu (Japan)": {
-      "status": "Unknown",
-      "notes": "",
-      "version": "v124"
+      "status": "Working",
+      "notes": "Missing samples: uses ADPCM speech chip with internal ROM (not dumped)",
+      "version": "v125"
     },
     "Moero!! Pro Yakyuu (Japan) (Rev 1)": {
-      "status": "Unknown",
-      "notes": "",
-      "version": "v124"
+      "status": "Working",
+      "notes": "Missing samples: uses ADPCM speech chip with internal ROM (not dumped)",
+      "version": "v125"
     },
     "Moero!! Pro Yakyuu (Japan) (Rev 2)": {
-      "status": "Unknown",
-      "notes": "",
-      "version": "v124"
+      "status": "Working",
+      "notes": "Missing samples: uses ADPCM speech chip with internal ROM (not dumped)",
+      "version": "v125"
     },
     "Moero!! Pro Yakyuu (Japan) (Rev 3)": {
-      "status": "Unknown",
-      "notes": "",
-      "version": "v124"
+      "status": "Working",
+      "notes": "Missing samples: uses ADPCM speech chip with internal ROM (not dumped)",
+      "version": "v125"
     },
     "Moeru! Oniisan (Japan)": {
       "status": "Unknown",
@@ -6776,9 +6776,9 @@
       "version": "v124"
     },
     "Mouryou Senki Madara (Japan)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "Mr. Gimmick (Europe)": {
       "status": "Unknown",
@@ -6861,14 +6861,14 @@
       "version": "v124"
     },
     "Namco Prism Zone - Dream Master (Japan)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "Namcot Mahjong III - Mahjong Tengoku (Japan)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "Nangoku Shirei!! - Spy vs Spy (Japan)": {
       "status": "Unknown",
@@ -6891,9 +6891,9 @@
       "version": "v124"
     },
     "Napoleon Senki (Japan)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "NARC (USA)": {
       "status": "Unknown",
@@ -7056,14 +7056,14 @@
       "version": "v124"
     },
     "Ninja Jajamaru - Ginga Daisakusen (Japan)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "Ninja Jajamaru-kun (Japan)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "Ninja Kid (USA)": {
       "status": "Unknown",
@@ -7261,9 +7261,9 @@
       "version": "v124"
     },
     "Operation Wolf (Japan)": {
-      "status": "Unknown",
-      "notes": "",
-      "version": "v124"
+      "status": "Working",
+      "notes": "Optional peripheral: Zapper",
+      "version": "v125"
     },
     "Operation Wolf (USA)": {
       "status": "Unknown",
@@ -7511,9 +7511,9 @@
       "version": "v124"
     },
     "Parodius Da! (Japan)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "Peepar Time (Japan)": {
       "status": "Unknown",
@@ -7541,14 +7541,14 @@
       "version": "v124"
     },
     "Perman (Japan)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "Perman Part 2 - Himitsu Kessha Madoodan o Taose! (Japan)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "Phantom Air Mission (Europe)": {
       "status": "Unknown",
@@ -7601,9 +7601,9 @@
       "version": "v124"
     },
     "Pinball Quest (Japan)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "Pinball Quest (USA)": {
       "status": "Unknown",
@@ -7631,14 +7631,14 @@
       "version": "v124"
     },
     "Pizza Pop! (Japan)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "Plasma Ball (Japan)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "Platoon (USA)": {
       "status": "Unknown",
@@ -7701,9 +7701,9 @@
       "version": "v124"
     },
     "Power Blazer (Japan)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "Power Punch II (USA)": {
       "status": "Unknown",
@@ -7791,19 +7791,19 @@
       "version": "v124"
     },
     "Pro Yakyuu - Family Stadium '87 (Japan)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "Pro Yakyuu - Family Stadium '88 (Japan)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "Pro Yakyuu - Family Stadium (Japan)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "Pro Yakyuu Satsujin Jiken! (Japan)": {
       "status": "Unknown",
@@ -7901,14 +7901,14 @@
       "version": "v124"
     },
     "Quinty (Japan)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "R.B.I. Baseball (USA)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "R.C. Pro-Am (Europe)": {
       "status": "Unknown",
@@ -7941,9 +7941,9 @@
       "version": "v124"
     },
     "Racer Mini Yonku - Japan Cup (Japan)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "Racket Attack (Europe)": {
       "status": "Unknown",
@@ -8101,9 +8101,9 @@
       "version": "v124"
     },
     "Ring King (USA)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "Ripple Island (Japan)": {
       "status": "Unknown",
@@ -8431,9 +8431,9 @@
       "version": "v124"
     },
     "Saiyuuki World 2 - Tenjoukai no Majin (Japan)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "Sakigake!! Otoko Juku - Shippuu Ichi Gou Sei (Japan)": {
       "status": "Unknown",
@@ -8446,9 +8446,9 @@
       "version": "v124"
     },
     "Salamander (Japan)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "Samsara Naga (Japan)": {
       "status": "Unknown",
@@ -8491,9 +8491,9 @@
       "version": "v124"
     },
     "Sanma no Meitantei (Japan)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "Sanrio Carnival (Japan)": {
       "status": "Unknown",
@@ -8596,9 +8596,9 @@
       "version": "v124"
     },
     "SD Keiji - Blader (Japan)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "SD Sengoku Bushou Retsuden (Japan)": {
       "status": "Unknown",
@@ -8781,9 +8781,9 @@
       "version": "v124"
     },
     "Shin Moero!! Pro Yakyuu (Japan)": {
-      "status": "Unknown",
-      "notes": "",
-      "version": "v124"
+      "status": "Working",
+      "notes": "Missing samples: uses ADPCM speech chip with internal ROM (not dumped)",
+      "version": "v125"
     },
     "Shin Satomi Hakken-Den - Hikari to Yami no Tatakai (Japan)": {
       "status": "Unknown",
@@ -8851,9 +8851,9 @@
       "version": "v124"
     },
     "Side Pocket (Japan)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "Side Pocket (USA)": {
       "status": "Unknown",
@@ -8956,9 +8956,9 @@
       "version": "v124"
     },
     "Sky Kid (Japan)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "Sky Kid (USA)": {
       "status": "Unknown",
@@ -9171,9 +9171,9 @@
       "version": "v124"
     },
     "Spartan X 2 (Japan)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "Spelunker (Japan)": {
       "status": "Unknown",
@@ -9201,14 +9201,14 @@
       "version": "v124"
     },
     "Splatterhouse - Wanpaku Graffiti (Japan)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "Splatterhouse - Wanpaku Graffiti (World) (Namcot Collection, Namco Museum Archives Vol 1)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "Spot (Japan)": {
       "status": "Unknown",
@@ -9471,9 +9471,9 @@
       "version": "v124"
     },
     "Super Chinese (Japan)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "Super Chinese 2 - Dragon Kid (Japan)": {
       "status": "Unknown",
@@ -9676,9 +9676,9 @@
       "version": "v124"
     },
     "Super Xevious - Gump no Nazo (Japan)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "Super Xevious - Gump no Nazo (USA, Europe) (Namco Museum Archives Vol 2)": {
       "status": "Unknown",
@@ -9786,9 +9786,9 @@
       "version": "v124"
     },
     "Taito Grand Prix - Eikou e no License (Japan)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "Taiyou no Shinden (Japan)": {
       "status": "Unknown",
@@ -9841,9 +9841,9 @@
       "version": "v124"
     },
     "Takeshi no Sengoku Fuuunji (Japan)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "TaleSpin (Europe)": {
       "status": "Unknown",
@@ -10016,9 +10016,9 @@
       "version": "v124"
     },
     "Teenage Mutant Ninja Turtles (Japan)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "Teenage Mutant Ninja Turtles (USA)": {
       "status": "Unknown",
@@ -10031,9 +10031,9 @@
       "version": "v124"
     },
     "Teenage Mutant Ninja Turtles 2 - The Manhattan Project (Japan)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "Teenage Mutant Ninja Turtles II - The Arcade Game (Australia)": {
       "status": "Unknown",
@@ -10076,9 +10076,9 @@
       "version": "v124"
     },
     "Tenkaichi Bushi - Keru Naguuru (Japan)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "Tennis (Europe)": {
       "status": "Unknown",
@@ -10096,9 +10096,9 @@
       "version": "v124"
     },
     "Terao no Dosukoi Oozumou (Japan)": {
-      "status": "Unknown",
-      "notes": "",
-      "version": "v124"
+      "status": "Working",
+      "notes": "Missing samples: uses ADPCM speech chip with internal ROM (not dumped)",
+      "version": "v125"
     },
     "Terminator 2 (Japan)": {
       "status": "Unknown",
@@ -10191,9 +10191,9 @@
       "version": "v124"
     },
     "Tetsuwan Atom (Japan)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "Thexder (Japan)": {
       "status": "Unknown",
@@ -10276,9 +10276,9 @@
       "version": "v124"
     },
     "Tiny Toon Adventures (Japan)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "Tiny Toon Adventures (USA)": {
       "status": "Unknown",
@@ -10286,9 +10286,9 @@
       "version": "v124"
     },
     "Tiny Toon Adventures 2 - Montana Land e Youkoso (Japan)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "Tiny Toon Adventures 2 - Trouble in Wackyland (Europe)": {
       "status": "Unknown",
@@ -10416,9 +10416,9 @@
       "version": "v124"
     },
     "Top Striker (Japan)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "Total Recall (Europe)": {
       "status": "Unknown",
@@ -10456,9 +10456,9 @@
       "version": "v124"
     },
     "Toukon Club (Japan)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "Toukyou Pachi-Slot Adventure (Japan)": {
       "status": "Unknown",
@@ -10561,9 +10561,9 @@
       "version": "v124"
     },
     "Tsuru Pika Hagemaru - Mezase! Tsuru Seko no Akashi (Japan)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "Turbo Racing (Europe)": {
       "status": "Unknown",
@@ -10586,14 +10586,14 @@
       "version": "v124"
     },
     "TwinBee (Japan)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "TwinBee 3 - Poko Poko Daimaou (Japan)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "U.S. Championship V'Ball (Japan)": {
       "status": "Unknown",
@@ -10606,9 +10606,9 @@
       "version": "v124"
     },
     "Uchuusen Cosmo Carrier (Japan)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "Ufouria - The Saga (Europe)": {
       "status": "Unknown",
@@ -10711,14 +10711,14 @@
       "version": "v124"
     },
     "Urusei Yatsura - Lum no Wedding Bell (Japan)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "USA Ice Hockey in FC (Japan)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "Ushio to Tora - Shinen no Taiyou (Japan)": {
       "status": "Unknown",
@@ -10731,9 +10731,9 @@
       "version": "v124"
     },
     "Valkyrie no Bouken - Toki no Kagi Densetsu (Japan)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "Vegas Connection - Casino kara Ai o Komete (Japan)": {
       "status": "Unknown",
@@ -10781,24 +10781,24 @@
       "version": "v124"
     },
     "Wagyan Land (Japan)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "Wagyan Land 2 (Japan)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "Wagyan Land 3 (Japan)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "Wai Wai World 2 - SOS!! Paseri Jou (Japan)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "Wall Street Kid (USA)": {
       "status": "Unknown",
@@ -11231,9 +11231,9 @@
       "version": "v124"
     },
     "Youkai Club (Japan)": {
-      "status": "Unknown",
+      "status": "Working",
       "notes": "",
-      "version": "v124"
+      "version": "v125"
     },
     "Youkai Douchuuki (Japan)": {
       "status": "Unknown",


### PR DESCRIPTION
These are the games I test myself so far.

For the few games with missing ADPCM samples I consider those "Working"; the chip plays sound data stored on internal rom which is undumped according to latest mame dats, so we already have the best emulation that can be done now for those games. I can change to "Partially Working" if you feel those belong there.